### PR TITLE
ES-4519: Add settlement property to debt estate item resource representations

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BankAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BankAccountResourceRepresentation.cs
@@ -18,5 +18,5 @@ public class BankAccountResourceRepresentation : EstateItemResourceRepresentatio
     public string? TypeOfAccount { get; init; }
     public string? NotPassedDetails { get; init; }
     public decimal ProportionOwned { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BankAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BankAccountResourceRepresentation.cs
@@ -18,4 +18,5 @@ public class BankAccountResourceRepresentation : EstateItemResourceRepresentatio
     public string? TypeOfAccount { get; init; }
     public string? NotPassedDetails { get; init; }
     public decimal ProportionOwned { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BuildingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BuildingResourceRepresentation.cs
@@ -40,5 +40,5 @@ public class BuildingResourceRepresentation : EstateItemResourceRepresentation
     public bool IsSubjectToSpecialFactors { get; init; }
     public string? SpecialFactorsDescription { get; init; }
     public bool IsCharityDonation { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BuildingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BuildingResourceRepresentation.cs
@@ -40,4 +40,5 @@ public class BuildingResourceRepresentation : EstateItemResourceRepresentation
     public bool IsSubjectToSpecialFactors { get; init; }
     public string? SpecialFactorsDescription { get; init; }
     public bool IsCharityDonation { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BusinessInterestResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BusinessInterestResourceRepresentation.cs
@@ -16,4 +16,5 @@ public class BusinessInterestResourceRepresentation : EstateItemResourceRepresen
     public bool IsHeritable { get; init; }
     public bool IsValidForInheritanceTax { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/BusinessInterestResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/BusinessInterestResourceRepresentation.cs
@@ -16,5 +16,5 @@ public class BusinessInterestResourceRepresentation : EstateItemResourceRepresen
     public bool IsHeritable { get; init; }
     public bool IsValidForInheritanceTax { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CashIsaResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CashIsaResourceRepresentation.cs
@@ -14,5 +14,5 @@ public class CashIsaResourceRepresentation : EstateItemResourceRepresentation
     public decimal? ConfirmedBalance { get; init; }
     public decimal? InterestUpToDateOfDeath { get; init; }
     public AddressResourceRepresentation Address { get; init; } = null!;
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CashIsaResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CashIsaResourceRepresentation.cs
@@ -14,4 +14,5 @@ public class CashIsaResourceRepresentation : EstateItemResourceRepresentation
     public decimal? ConfirmedBalance { get; init; }
     public decimal? InterestUpToDateOfDeath { get; init; }
     public AddressResourceRepresentation Address { get; init; } = null!;
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CashSavingsAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CashSavingsAccountResourceRepresentation.cs
@@ -18,4 +18,5 @@ public class CashSavingsAccountResourceRepresentation : EstateItemResourceRepres
     public bool? IsPassedToSurvivingJointOwner { get; init; }
     public string? NotPassedDetails { get; init; }
     public decimal ProportionOwned { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CashSavingsAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CashSavingsAccountResourceRepresentation.cs
@@ -18,5 +18,5 @@ public class CashSavingsAccountResourceRepresentation : EstateItemResourceRepres
     public bool? IsPassedToSurvivingJointOwner { get; init; }
     public string? NotPassedDetails { get; init; }
     public decimal ProportionOwned { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CreditCardOrPersonalLoanResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CreditCardOrPersonalLoanResourceRepresentation.cs
@@ -12,4 +12,5 @@ public class CreditCardOrPersonalLoanResourceRepresentation : EstateItemResource
     public string? AccountNumber { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CreditCardOrPersonalLoanResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CreditCardOrPersonalLoanResourceRepresentation.cs
@@ -12,5 +12,5 @@ public class CreditCardOrPersonalLoanResourceRepresentation : EstateItemResource
     public string? AccountNumber { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CryptocurrencyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CryptocurrencyResourceRepresentation.cs
@@ -15,5 +15,5 @@ public class CryptocurrencyResourceRepresentation : EstateItemResourceRepresenta
     public string? NotPassedDetails { get; init; }
     public decimal? InvestmentValue { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CryptocurrencyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CryptocurrencyResourceRepresentation.cs
@@ -15,4 +15,5 @@ public class CryptocurrencyResourceRepresentation : EstateItemResourceRepresenta
     public string? NotPassedDetails { get; init; }
     public decimal? InvestmentValue { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/EndowmentPolicyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/EndowmentPolicyResourceRepresentation.cs
@@ -13,5 +13,5 @@ public class EndowmentPolicyResourceRepresentation : EstateItemResourceRepresent
     public decimal? BonusDue { get; init; }
     public bool PaysOnDeathOfDeceased { get; init; }
     public string? Comments { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/EndowmentPolicyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/EndowmentPolicyResourceRepresentation.cs
@@ -13,4 +13,5 @@ public class EndowmentPolicyResourceRepresentation : EstateItemResourceRepresent
     public decimal? BonusDue { get; init; }
     public bool PaysOnDeathOfDeceased { get; init; }
     public string? Comments { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemResourceRepresentation.cs
@@ -9,7 +9,5 @@ public abstract class EstateItemResourceRepresentation
     public string? Notes { get; init; }
     public bool IsArchived { get; init; }
     public bool IsComplete { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
-
     public decimal DateOfDeathValue { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemSettlementResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemSettlementResourceRepresentation.cs
@@ -1,0 +1,9 @@
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public class EstateItemSettlementResourceRepresentation
+{
+    public Guid? ThirdPartyCreditorId { get; init; }
+    public decimal? Value { get; init; }
+    public Guid? CaseItemId { get; init; }
+    public DateTime? ReceivedAt { get; init; }
+}

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/IncomeBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/IncomeBondResourceRepresentation.cs
@@ -14,5 +14,5 @@ public class IncomeBondResourceRepresentation : EstateItemResourceRepresentation
     public decimal ProportionOwned { get; init; }
     public bool? IsPassedToSurvivingJointOwner { get; init; }
     public string? NotPassedDetails { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/IncomeBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/IncomeBondResourceRepresentation.cs
@@ -14,4 +14,5 @@ public class IncomeBondResourceRepresentation : EstateItemResourceRepresentation
     public decimal ProportionOwned { get; init; }
     public bool? IsPassedToSurvivingJointOwner { get; init; }
     public string? NotPassedDetails { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/InvestmentBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/InvestmentBondResourceRepresentation.cs
@@ -15,5 +15,5 @@ public class InvestmentBondResourceRepresentation : EstateItemResourceRepresenta
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
     public bool IsValidForInheritanceTax { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/InvestmentBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/InvestmentBondResourceRepresentation.cs
@@ -15,4 +15,5 @@ public class InvestmentBondResourceRepresentation : EstateItemResourceRepresenta
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
     public bool IsValidForInheritanceTax { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
@@ -36,4 +36,5 @@ public class LandResourceRepresentation : EstateItemResourceRepresentation
     public bool IsSubjectToSpecialFactors { get; init; }
     public string? SpecialFactorsDescription { get; init; }
     public bool IsCharityDonation { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
@@ -36,5 +36,5 @@ public class LandResourceRepresentation : EstateItemResourceRepresentation
     public bool IsSubjectToSpecialFactors { get; init; }
     public string? SpecialFactorsDescription { get; init; }
     public bool IsCharityDonation { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/LifePolicyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/LifePolicyResourceRepresentation.cs
@@ -13,4 +13,5 @@ public class LifePolicyResourceRepresentation : EstateItemResourceRepresentation
     public bool PaysOnDeathOfDeceased { get; init; }
     public string? BeneficiaryDetails { get; init; }
     public string? Comments { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/LifePolicyResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/LifePolicyResourceRepresentation.cs
@@ -13,5 +13,5 @@ public class LifePolicyResourceRepresentation : EstateItemResourceRepresentation
     public bool PaysOnDeathOfDeceased { get; init; }
     public string? BeneficiaryDetails { get; init; }
     public string? Comments { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousAssetResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousAssetResourceRepresentation.cs
@@ -18,5 +18,5 @@ public class MiscellaneousAssetResourceRepresentation : EstateItemResourceRepres
     public bool IsValidForInheritanceTax { get; init; }
     public bool? IsCharityDonation { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousAssetResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousAssetResourceRepresentation.cs
@@ -18,4 +18,5 @@ public class MiscellaneousAssetResourceRepresentation : EstateItemResourceRepres
     public bool IsValidForInheritanceTax { get; init; }
     public bool? IsCharityDonation { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousDebtResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousDebtResourceRepresentation.cs
@@ -13,4 +13,5 @@ public class MiscellaneousDebtResourceRepresentation : EstateItemResourceReprese
     public string? Provider { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousDebtResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MiscellaneousDebtResourceRepresentation.cs
@@ -13,5 +13,5 @@ public class MiscellaneousDebtResourceRepresentation : EstateItemResourceReprese
     public string? Provider { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MortgageResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MortgageResourceRepresentation.cs
@@ -12,4 +12,5 @@ public class MortgageResourceRepresentation : EstateItemResourceRepresentation
     public string? MortgageType { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/MortgageResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/MortgageResourceRepresentation.cs
@@ -12,5 +12,5 @@ public class MortgageResourceRepresentation : EstateItemResourceRepresentation
     public string? MortgageType { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/NomineeInvestmentAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/NomineeInvestmentAccountResourceRepresentation.cs
@@ -15,4 +15,5 @@ public class NomineeInvestmentAccountResourceRepresentation : EstateItemResource
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
     public bool? IsValidForInheritanceTax { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/NomineeInvestmentAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/NomineeInvestmentAccountResourceRepresentation.cs
@@ -15,5 +15,5 @@ public class NomineeInvestmentAccountResourceRepresentation : EstateItemResource
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
     public bool? IsValidForInheritanceTax { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PensionResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PensionResourceRepresentation.cs
@@ -12,4 +12,5 @@ public class PensionResourceRepresentation : EstateItemResourceRepresentation
     public decimal? DeathBenefitValuePayable { get; init; }
     public string? BeneficiaryDetails { get; init; }
     public bool? IsValidForInheritanceTax { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PensionResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PensionResourceRepresentation.cs
@@ -12,5 +12,5 @@ public class PensionResourceRepresentation : EstateItemResourceRepresentation
     public decimal? DeathBenefitValuePayable { get; init; }
     public string? BeneficiaryDetails { get; init; }
     public bool? IsValidForInheritanceTax { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
@@ -16,4 +16,5 @@ public class PhysicalShareholdingResourceRepresentation : EstateItemResourceRepr
     public string? NotPassedDetails { get; init; }
     public decimal? DividendDue { get; init; }
     public bool IsQuotedOnLondonStockExchange { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
@@ -16,5 +16,5 @@ public class PhysicalShareholdingResourceRepresentation : EstateItemResourceRepr
     public string? NotPassedDetails { get; init; }
     public decimal? DividendDue { get; init; }
     public bool IsQuotedOnLondonStockExchange { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PremiumBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PremiumBondResourceRepresentation.cs
@@ -10,5 +10,5 @@ public class PremiumBondResourceRepresentation : EstateItemResourceRepresentatio
     public string? BondNumber { get; init; }
     public decimal? ValueAtDateOfDeath { get; init; }
     public decimal? ValueOfUnclaimedPrizes { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PremiumBondResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PremiumBondResourceRepresentation.cs
@@ -10,4 +10,5 @@ public class PremiumBondResourceRepresentation : EstateItemResourceRepresentatio
     public string? BondNumber { get; init; }
     public decimal? ValueAtDateOfDeath { get; init; }
     public decimal? ValueOfUnclaimedPrizes { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/SecuredLoanResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/SecuredLoanResourceRepresentation.cs
@@ -13,4 +13,5 @@ public class SecuredLoanResourceRepresentation : EstateItemResourceRepresentatio
     public bool HasProviderBeenAdvised { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/SecuredLoanResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/SecuredLoanResourceRepresentation.cs
@@ -13,5 +13,5 @@ public class SecuredLoanResourceRepresentation : EstateItemResourceRepresentatio
     public bool HasProviderBeenAdvised { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/StateBenefitOverpaymentResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/StateBenefitOverpaymentResourceRepresentation.cs
@@ -7,4 +7,5 @@ public class StateBenefitOverpaymentResourceRepresentation : EstateItemResourceR
 {
     public decimal? Amount { get; init; }
     public bool HasBeenRepaid { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/StateBenefitOverpaymentResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/StateBenefitOverpaymentResourceRepresentation.cs
@@ -7,5 +7,5 @@ public class StateBenefitOverpaymentResourceRepresentation : EstateItemResourceR
 {
     public decimal? Amount { get; init; }
     public bool HasBeenRepaid { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/StoreCardOrCatalogueAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/StoreCardOrCatalogueAccountResourceRepresentation.cs
@@ -11,4 +11,5 @@ public class StoreCardOrCatalogueAccountResourceRepresentation : EstateItemResou
     public string? Provider { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/StoreCardOrCatalogueAccountResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/StoreCardOrCatalogueAccountResourceRepresentation.cs
@@ -11,5 +11,5 @@ public class StoreCardOrCatalogueAccountResourceRepresentation : EstateItemResou
     public string? Provider { get; init; }
     public bool HasProviderBeenAdvised { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/UKGovAndMunicipalSecuritiesResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/UKGovAndMunicipalSecuritiesResourceRepresentation.cs
@@ -11,4 +11,5 @@ public class UKGovAndMunicipalSecuritiesResourceRepresentation : EstateItemResou
     public string? DescriptionOfStock { get; init; }
     public decimal? UnitPrice { get; init; }
     public decimal? InterestDue { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/UKGovAndMunicipalSecuritiesResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/UKGovAndMunicipalSecuritiesResourceRepresentation.cs
@@ -11,5 +11,5 @@ public class UKGovAndMunicipalSecuritiesResourceRepresentation : EstateItemResou
     public string? DescriptionOfStock { get; init; }
     public decimal? UnitPrice { get; init; }
     public decimal? InterestDue { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/UnitTrustResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/UnitTrustResourceRepresentation.cs
@@ -14,5 +14,5 @@ public class UnitTrustResourceRepresentation : EstateItemResourceRepresentation
     public string? NotPassedDetails { get; init; }
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/UnitTrustResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/UnitTrustResourceRepresentation.cs
@@ -14,4 +14,5 @@ public class UnitTrustResourceRepresentation : EstateItemResourceRepresentation
     public string? NotPassedDetails { get; init; }
     public decimal? DividendDue { get; init; }
     public decimal? InvestmentValue { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleFinanceResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleFinanceResourceRepresentation.cs
@@ -12,4 +12,5 @@ public class VehicleFinanceResourceRepresentation : EstateItemResourceRepresenta
     public bool HasProviderBeenAdvised { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
+    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleFinanceResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleFinanceResourceRepresentation.cs
@@ -12,5 +12,5 @@ public class VehicleFinanceResourceRepresentation : EstateItemResourceRepresenta
     public bool HasProviderBeenAdvised { get; init; }
     public Guid? LinkedEstateItemId { get; init; }
     public decimal? DebtValue { get; init; }
-    public EstateItemSettlementResourceRepresentation? Settlement { get; init; }
+    public EstateItemSettlementResourceRepresentation Settlement { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleResourceRepresentation.cs
@@ -25,4 +25,5 @@ public class VehicleResourceRepresentation : EstateItemResourceRepresentation
     public int? YearOfManufacture { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
     public DateTime? DateOfSale { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/VehicleResourceRepresentation.cs
@@ -25,5 +25,5 @@ public class VehicleResourceRepresentation : EstateItemResourceRepresentation
     public int? YearOfManufacture { get; init; }
     public decimal? GrossSaleProceeds { get; init; }
     public DateTime? DateOfSale { get; init; }
-    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
+    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BankAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BankAccountEstateItemJsonBuilder.cs
@@ -27,7 +27,7 @@ public class BankAccountEstateItemJsonBuilder : EstateItemJsonBuilder<BankAccoun
         jsonObject.Add("typeOfAccount", resourceRepresentation.TypeOfAccount);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BankAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BankAccountEstateItemJsonBuilder.cs
@@ -27,6 +27,7 @@ public class BankAccountEstateItemJsonBuilder : EstateItemJsonBuilder<BankAccoun
         jsonObject.Add("typeOfAccount", resourceRepresentation.TypeOfAccount);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BuildingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BuildingEstateItemJsonBuilder.cs
@@ -50,6 +50,7 @@ public class BuildingEstateItemJsonBuilder : EstateItemJsonBuilder<BuildingResou
         jsonObject.Add("isSubjectToSpecialFactors", resourceRepresentation.IsSubjectToSpecialFactors);
         jsonObject.Add("specialFactorsDescription", resourceRepresentation.SpecialFactorsDescription);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BuildingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BuildingEstateItemJsonBuilder.cs
@@ -50,7 +50,7 @@ public class BuildingEstateItemJsonBuilder : EstateItemJsonBuilder<BuildingResou
         jsonObject.Add("isSubjectToSpecialFactors", resourceRepresentation.IsSubjectToSpecialFactors);
         jsonObject.Add("specialFactorsDescription", resourceRepresentation.SpecialFactorsDescription);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BusinessInterestEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BusinessInterestEstateItemJsonBuilder.cs
@@ -25,7 +25,7 @@ public class BusinessInterestEstateItemJsonBuilder : EstateItemJsonBuilder<Busin
         jsonObject.Add("isHeritable", resourceRepresentation.IsHeritable);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BusinessInterestEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/BusinessInterestEstateItemJsonBuilder.cs
@@ -25,6 +25,7 @@ public class BusinessInterestEstateItemJsonBuilder : EstateItemJsonBuilder<Busin
         jsonObject.Add("isHeritable", resourceRepresentation.IsHeritable);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashIsaEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashIsaEstateItemJsonBuilder.cs
@@ -23,6 +23,7 @@ public class CashIsaEstateItemJsonBuilder : EstateItemJsonBuilder<CashIsaResourc
         jsonObject.Add("confirmedBalance", resourceRepresentation.ConfirmedBalance);
         jsonObject.Add("interestUpToDateOfDeath", resourceRepresentation.InterestUpToDateOfDeath);
         jsonObject.Add("address", AddressJsonBuilder.Build(resourceRepresentation.Address));
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashIsaEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashIsaEstateItemJsonBuilder.cs
@@ -23,7 +23,7 @@ public class CashIsaEstateItemJsonBuilder : EstateItemJsonBuilder<CashIsaResourc
         jsonObject.Add("confirmedBalance", resourceRepresentation.ConfirmedBalance);
         jsonObject.Add("interestUpToDateOfDeath", resourceRepresentation.InterestUpToDateOfDeath);
         jsonObject.Add("address", AddressJsonBuilder.Build(resourceRepresentation.Address));
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashSavingsAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashSavingsAccountEstateItemJsonBuilder.cs
@@ -27,6 +27,7 @@ public class CashSavingsAccountEstateItemJsonBuilder : EstateItemJsonBuilder<Cas
         jsonObject.Add("isPassedToSurvivingJointOwner", resourceRepresentation.IsPassedToSurvivingJointOwner);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashSavingsAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CashSavingsAccountEstateItemJsonBuilder.cs
@@ -27,7 +27,7 @@ public class CashSavingsAccountEstateItemJsonBuilder : EstateItemJsonBuilder<Cas
         jsonObject.Add("isPassedToSurvivingJointOwner", resourceRepresentation.IsPassedToSurvivingJointOwner);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CreditCardOrPersonalLoanEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CreditCardOrPersonalLoanEstateItemJsonBuilder.cs
@@ -24,7 +24,7 @@ public class
         jsonObject.Add("accountNumber", resourceRepresentation.AccountNumber);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CreditCardOrPersonalLoanEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CreditCardOrPersonalLoanEstateItemJsonBuilder.cs
@@ -24,6 +24,7 @@ public class
         jsonObject.Add("accountNumber", resourceRepresentation.AccountNumber);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CryptocurrencyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CryptocurrencyEstateItemJsonBuilder.cs
@@ -24,7 +24,7 @@ public class CryptocurrencyEstateItemJsonBuilder : EstateItemJsonBuilder<Cryptoc
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CryptocurrencyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/CryptocurrencyEstateItemJsonBuilder.cs
@@ -24,6 +24,7 @@ public class CryptocurrencyEstateItemJsonBuilder : EstateItemJsonBuilder<Cryptoc
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EndowmentPolicyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EndowmentPolicyEstateItemJsonBuilder.cs
@@ -22,6 +22,7 @@ public class EndowmentPolicyEstateItemJsonBuilder : EstateItemJsonBuilder<Endowm
         jsonObject.Add("bonusDue", resourceRepresentation.BonusDue);
         jsonObject.Add("paysOnDeathOfDeceased", resourceRepresentation.PaysOnDeathOfDeceased);
         jsonObject.Add("comments", resourceRepresentation.Comments);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EndowmentPolicyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EndowmentPolicyEstateItemJsonBuilder.cs
@@ -22,7 +22,7 @@ public class EndowmentPolicyEstateItemJsonBuilder : EstateItemJsonBuilder<Endowm
         jsonObject.Add("bonusDue", resourceRepresentation.BonusDue);
         jsonObject.Add("paysOnDeathOfDeceased", resourceRepresentation.PaysOnDeathOfDeceased);
         jsonObject.Add("comments", resourceRepresentation.Comments);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EstateItemJsonBuilder.cs
@@ -21,23 +21,16 @@ public abstract class EstateItemJsonBuilder<TEstateItem> : IEstateItemJsonBuilde
 
     protected abstract JsonObject InnerBuild(JsonObject jsonObject, TEstateItem resourceRepresentation);
 
-    private static JsonObject BuildEstateItem(EstateItemResourceRepresentation resourceRepresentation)
-    {
-        var jsonObject = new JsonObject();
-
-        jsonObject.Add("id", resourceRepresentation.Id);
-        jsonObject.Add("location", resourceRepresentation.Location.ToString("G"));
-        jsonObject.Add("createdAt", resourceRepresentation.CreatedAt);
-        jsonObject.Add("updatedAt", resourceRepresentation.UpdatedAt);
-        jsonObject.Add("notes", resourceRepresentation.Notes);
-        jsonObject.Add("isArchived", resourceRepresentation.IsArchived);
-        jsonObject.Add("isComplete", resourceRepresentation.IsComplete);
-        jsonObject.Add("realisation",
-            resourceRepresentation.Realisation is null
-                ? null
-                : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
-        jsonObject.Add("dateOfDeathValue", resourceRepresentation.DateOfDeathValue);
-
-        return jsonObject;
-    }
+    private static JsonObject BuildEstateItem(EstateItemResourceRepresentation resourceRepresentation) =>
+        new()
+        {
+            {"id", resourceRepresentation.Id},
+            {"location", resourceRepresentation.Location.ToString("G")},
+            {"createdAt", resourceRepresentation.CreatedAt},
+            {"updatedAt", resourceRepresentation.UpdatedAt},
+            {"notes", resourceRepresentation.Notes},
+            {"isArchived", resourceRepresentation.IsArchived},
+            {"isComplete", resourceRepresentation.IsComplete},
+            {"dateOfDeathValue", resourceRepresentation.DateOfDeathValue}
+        };
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EstateItemSettlementJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/EstateItemSettlementJsonBuilder.cs
@@ -3,14 +3,14 @@ using Exizent.CaseManagement.Client.Models.EstateItems;
 
 namespace Exizent.CaseManagement.Client.Tests.JsonBuilders.EstateItems;
 
-public static class EstateItemRealisationJsonBuilder
+public static class EstateItemSettlementJsonBuilder
 {
-    public static JsonObject Build(EstateItemRealisationResourceRepresentation resourceRepresentation) =>
+    public static JsonObject Build(EstateItemSettlementResourceRepresentation resourceRepresentation) =>
         new()
         {
             {"receivedAt", resourceRepresentation.ReceivedAt},
             {"value", resourceRepresentation.Value},
-            {"destination", resourceRepresentation.Destination.ToString()},
-            {"otherDestination", resourceRepresentation.OtherDestination}
+            {"caseItemId", resourceRepresentation.CaseItemId},
+            {"thirdPartyCreditorId", resourceRepresentation.ThirdPartyCreditorId}
         };
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/IncomeBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/IncomeBondEstateItemJsonBuilder.cs
@@ -23,7 +23,7 @@ public class IncomeBondEstateItemJsonBuilder : EstateItemJsonBuilder<IncomeBondR
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
         jsonObject.Add("isPassedToSurvivingJointOwner", resourceRepresentation.IsPassedToSurvivingJointOwner);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
          
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/IncomeBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/IncomeBondEstateItemJsonBuilder.cs
@@ -23,6 +23,7 @@ public class IncomeBondEstateItemJsonBuilder : EstateItemJsonBuilder<IncomeBondR
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
         jsonObject.Add("isPassedToSurvivingJointOwner", resourceRepresentation.IsPassedToSurvivingJointOwner);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
          
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/InvestmentBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/InvestmentBondEstateItemJsonBuilder.cs
@@ -24,7 +24,7 @@ public class InvestmentBondEstateItemJsonBuilder : EstateItemJsonBuilder<Investm
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/InvestmentBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/InvestmentBondEstateItemJsonBuilder.cs
@@ -24,6 +24,7 @@ public class InvestmentBondEstateItemJsonBuilder : EstateItemJsonBuilder<Investm
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
@@ -45,6 +45,8 @@ public class LandEstateItemJsonBuilder : EstateItemJsonBuilder<LandResourceRepre
         jsonObject.Add("isSubjectToSpecialFactors", resourceRepresentation.IsSubjectToSpecialFactors);
         jsonObject.Add("specialFactorsDescription", resourceRepresentation.SpecialFactorsDescription);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
@@ -45,7 +45,7 @@ public class LandEstateItemJsonBuilder : EstateItemJsonBuilder<LandResourceRepre
         jsonObject.Add("isSubjectToSpecialFactors", resourceRepresentation.IsSubjectToSpecialFactors);
         jsonObject.Add("specialFactorsDescription", resourceRepresentation.SpecialFactorsDescription);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
 
         return jsonObject;

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LifePolicyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LifePolicyEstateItemJsonBuilder.cs
@@ -22,6 +22,7 @@ public class LifePolicyEstateItemJsonBuilder : EstateItemJsonBuilder<LifePolicyR
         jsonObject.Add("paysOnDeathOfDeceased", resourceRepresentation.PaysOnDeathOfDeceased);
         jsonObject.Add("beneficiaryDetails", resourceRepresentation.BeneficiaryDetails);
         jsonObject.Add("comments", resourceRepresentation.Comments);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LifePolicyEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LifePolicyEstateItemJsonBuilder.cs
@@ -22,7 +22,7 @@ public class LifePolicyEstateItemJsonBuilder : EstateItemJsonBuilder<LifePolicyR
         jsonObject.Add("paysOnDeathOfDeceased", resourceRepresentation.PaysOnDeathOfDeceased);
         jsonObject.Add("beneficiaryDetails", resourceRepresentation.BeneficiaryDetails);
         jsonObject.Add("comments", resourceRepresentation.Comments);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousAssetEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousAssetEstateItemJsonBuilder.cs
@@ -27,7 +27,7 @@ public class MiscellaneousAssetEstateItemJsonBuilder : EstateItemJsonBuilder<Mis
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousAssetEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousAssetEstateItemJsonBuilder.cs
@@ -27,6 +27,7 @@ public class MiscellaneousAssetEstateItemJsonBuilder : EstateItemJsonBuilder<Mis
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousDebtEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousDebtEstateItemJsonBuilder.cs
@@ -22,7 +22,7 @@ public class MiscellaneousDebtEstateItemJsonBuilder : EstateItemJsonBuilder<Misc
         jsonObject.Add("provider", resourceRepresentation.Provider);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousDebtEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MiscellaneousDebtEstateItemJsonBuilder.cs
@@ -22,6 +22,7 @@ public class MiscellaneousDebtEstateItemJsonBuilder : EstateItemJsonBuilder<Misc
         jsonObject.Add("provider", resourceRepresentation.Provider);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MortgageEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MortgageEstateItemJsonBuilder.cs
@@ -21,7 +21,8 @@ public class MortgageEstateItemJsonBuilder : EstateItemJsonBuilder<MortgageResou
         jsonObject.Add("mortgageType", resourceRepresentation.MortgageType);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-         
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+ 
         return jsonObject;
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MortgageEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/MortgageEstateItemJsonBuilder.cs
@@ -21,7 +21,7 @@ public class MortgageEstateItemJsonBuilder : EstateItemJsonBuilder<MortgageResou
         jsonObject.Add("mortgageType", resourceRepresentation.MortgageType);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/NomineeInvestmentAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/NomineeInvestmentAccountEstateItemJsonBuilder.cs
@@ -37,6 +37,7 @@ public class NomineeInvestmentAccountEstateItemJsonBuilder : EstateItemJsonBuild
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/NomineeInvestmentAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/NomineeInvestmentAccountEstateItemJsonBuilder.cs
@@ -37,7 +37,7 @@ public class NomineeInvestmentAccountEstateItemJsonBuilder : EstateItemJsonBuild
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PensionEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PensionEstateItemJsonBuilder.cs
@@ -21,6 +21,7 @@ public class PensionEstateItemJsonBuilder : EstateItemJsonBuilder<PensionResourc
         jsonObject.Add("deathBenefitValuePayable", resourceRepresentation.DeathBenefitValuePayable);
         jsonObject.Add("beneficiaryDetails", resourceRepresentation.BeneficiaryDetails);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
          
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PensionEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PensionEstateItemJsonBuilder.cs
@@ -21,7 +21,7 @@ public class PensionEstateItemJsonBuilder : EstateItemJsonBuilder<PensionResourc
         jsonObject.Add("deathBenefitValuePayable", resourceRepresentation.DeathBenefitValuePayable);
         jsonObject.Add("beneficiaryDetails", resourceRepresentation.BeneficiaryDetails);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
          
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
@@ -25,7 +25,8 @@ public class PhysicalShareholdingEstateItemJsonBuilder : EstateItemJsonBuilder<P
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("isQuotedOnLondonStockExchange", resourceRepresentation.IsQuotedOnLondonStockExchange);
-          
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+ 
         return jsonObject;
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
@@ -25,7 +25,7 @@ public class PhysicalShareholdingEstateItemJsonBuilder : EstateItemJsonBuilder<P
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("isQuotedOnLondonStockExchange", resourceRepresentation.IsQuotedOnLondonStockExchange);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PremiumBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PremiumBondEstateItemJsonBuilder.cs
@@ -19,7 +19,7 @@ public class PremiumBondEstateItemJsonBuilder : EstateItemJsonBuilder<PremiumBon
         jsonObject.Add("bondNumber", resourceRepresentation.BondNumber);
         jsonObject.Add("valueAtDateOfDeath", resourceRepresentation.ValueAtDateOfDeath);
         jsonObject.Add("valueOfUnclaimedPrizes", resourceRepresentation.ValueOfUnclaimedPrizes);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PremiumBondEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PremiumBondEstateItemJsonBuilder.cs
@@ -19,6 +19,7 @@ public class PremiumBondEstateItemJsonBuilder : EstateItemJsonBuilder<PremiumBon
         jsonObject.Add("bondNumber", resourceRepresentation.BondNumber);
         jsonObject.Add("valueAtDateOfDeath", resourceRepresentation.ValueAtDateOfDeath);
         jsonObject.Add("valueOfUnclaimedPrizes", resourceRepresentation.ValueOfUnclaimedPrizes);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/SecuredLoanEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/SecuredLoanEstateItemJsonBuilder.cs
@@ -22,6 +22,7 @@ public class SecuredLoanEstateItemJsonBuilder : EstateItemJsonBuilder<SecuredLoa
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/SecuredLoanEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/SecuredLoanEstateItemJsonBuilder.cs
@@ -22,7 +22,7 @@ public class SecuredLoanEstateItemJsonBuilder : EstateItemJsonBuilder<SecuredLoa
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StateBenefitOverpaymentEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StateBenefitOverpaymentEstateItemJsonBuilder.cs
@@ -16,6 +16,7 @@ public class StateBenefitOverpaymentEstateItemJsonBuilder : EstateItemJsonBuilde
         jsonObject.Add("type", nameof(EstateItemType.StateBenefitOverpayment));
         jsonObject.Add("amount", resourceRepresentation.Amount);
         jsonObject.Add("hasBeenRepaid", resourceRepresentation.HasBeenRepaid);
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StateBenefitOverpaymentEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StateBenefitOverpaymentEstateItemJsonBuilder.cs
@@ -16,7 +16,7 @@ public class StateBenefitOverpaymentEstateItemJsonBuilder : EstateItemJsonBuilde
         jsonObject.Add("type", nameof(EstateItemType.StateBenefitOverpayment));
         jsonObject.Add("amount", resourceRepresentation.Amount);
         jsonObject.Add("hasBeenRepaid", resourceRepresentation.HasBeenRepaid);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StoreCardOrCatalogueAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StoreCardOrCatalogueAccountEstateItemJsonBuilder.cs
@@ -20,7 +20,7 @@ public class StoreCardOrCatalogueAccountEstateItemJsonBuilder : EstateItemJsonBu
         jsonObject.Add("provider", resourceRepresentation.Provider);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StoreCardOrCatalogueAccountEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/StoreCardOrCatalogueAccountEstateItemJsonBuilder.cs
@@ -20,6 +20,7 @@ public class StoreCardOrCatalogueAccountEstateItemJsonBuilder : EstateItemJsonBu
         jsonObject.Add("provider", resourceRepresentation.Provider);
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UKGovAndMunicipalSecuritiesEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UKGovAndMunicipalSecuritiesEstateItemJsonBuilder.cs
@@ -20,6 +20,7 @@ public class UKGovAndMunicipalSecuritiesEstateItemJsonBuilder : EstateItemJsonBu
         jsonObject.Add("descriptionOfStock", resourceRepresentation.DescriptionOfStock);
         jsonObject.Add("unitPrice", resourceRepresentation.UnitPrice);
         jsonObject.Add("interestDue", resourceRepresentation.InterestDue);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UKGovAndMunicipalSecuritiesEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UKGovAndMunicipalSecuritiesEstateItemJsonBuilder.cs
@@ -20,7 +20,7 @@ public class UKGovAndMunicipalSecuritiesEstateItemJsonBuilder : EstateItemJsonBu
         jsonObject.Add("descriptionOfStock", resourceRepresentation.DescriptionOfStock);
         jsonObject.Add("unitPrice", resourceRepresentation.UnitPrice);
         jsonObject.Add("interestDue", resourceRepresentation.InterestDue);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UnitTrustEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UnitTrustEstateItemJsonBuilder.cs
@@ -23,6 +23,7 @@ public class UnitTrustEstateItemJsonBuilder : EstateItemJsonBuilder<UnitTrustRes
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UnitTrustEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/UnitTrustEstateItemJsonBuilder.cs
@@ -23,7 +23,7 @@ public class UnitTrustEstateItemJsonBuilder : EstateItemJsonBuilder<UnitTrustRes
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("investmentValue", resourceRepresentation.InvestmentValue);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleEstateItemJsonBuilder.cs
@@ -34,7 +34,7 @@ public class VehicleEstateItemJsonBuilder : EstateItemJsonBuilder<VehicleResourc
         jsonObject.Add("yearOfManufacture", resourceRepresentation.YearOfManufacture);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
         jsonObject.Add("dateOfSale", resourceRepresentation.DateOfSale);
-        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
  
         return jsonObject;
     }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleEstateItemJsonBuilder.cs
@@ -34,7 +34,8 @@ public class VehicleEstateItemJsonBuilder : EstateItemJsonBuilder<VehicleResourc
         jsonObject.Add("yearOfManufacture", resourceRepresentation.YearOfManufacture);
         jsonObject.Add("grossSaleProceeds", resourceRepresentation.GrossSaleProceeds);
         jsonObject.Add("dateOfSale", resourceRepresentation.DateOfSale);
-       
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is null ? null : EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+ 
         return jsonObject;
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleFinanceEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleFinanceEstateItemJsonBuilder.cs
@@ -21,7 +21,8 @@ public class VehicleFinanceEstateItemJsonBuilder : EstateItemJsonBuilder<Vehicle
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-         
+        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+ 
         return jsonObject;
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleFinanceEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/VehicleFinanceEstateItemJsonBuilder.cs
@@ -21,7 +21,7 @@ public class VehicleFinanceEstateItemJsonBuilder : EstateItemJsonBuilder<Vehicle
         jsonObject.Add("hasProviderBeenAdvised", resourceRepresentation.HasProviderBeenAdvised);
         jsonObject.Add("linkedEstateItemId", resourceRepresentation.LinkedEstateItemId);
         jsonObject.Add("debtValue", resourceRepresentation.DebtValue);
-        jsonObject.Add("settlement", resourceRepresentation.Settlement is null ? null : EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
+        jsonObject.Add("settlement", EstateItemSettlementJsonBuilder.Build(resourceRepresentation.Settlement));
  
         return jsonObject;
     }


### PR DESCRIPTION
Moved realisation property out of estate item resource base class as estate items can have either realisation or settlement based on their type.