### PR TITLE
Removed IsHeritable from Land ResourceRepresentation as  it is always True

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/LandResourceRepresentation.cs
@@ -36,6 +36,5 @@ public class LandResourceRepresentation : EstateItemResourceRepresentation
     public bool IsSubjectToSpecialFactors { get; init; }
     public string? SpecialFactorsDescription { get; init; }
     public bool IsCharityDonation { get; init; }
-    public bool IsHeritable { get; init; }
     public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/LandEstateItemJsonBuilder.cs
@@ -45,7 +45,6 @@ public class LandEstateItemJsonBuilder : EstateItemJsonBuilder<LandResourceRepre
         jsonObject.Add("isSubjectToSpecialFactors", resourceRepresentation.IsSubjectToSpecialFactors);
         jsonObject.Add("specialFactorsDescription", resourceRepresentation.SpecialFactorsDescription);
         jsonObject.Add("isCharityDonation", resourceRepresentation.IsCharityDonation);
-        jsonObject.Add("isHeritable", resourceRepresentation.IsHeritable);        
         jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
 
 


### PR DESCRIPTION
We should only expose those properties on the API that can be different values.  IsHeritable on Land is always True and so should not be on the resource representation