### PR TITLE
Add basic Financial Gift representation

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemType.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/EstateItemType.cs
@@ -27,5 +27,6 @@ public enum EstateItemType
     UnitTrust,
     VehicleFinance,
     Vehicle,
-    UkGovAndMunicipalSecurities
+    UkGovAndMunicipalSecurities,
+    FinancialGift
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/FinancialGiftExemptionCategory.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/FinancialGiftExemptionCategory.cs
@@ -1,0 +1,15 @@
+﻿namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public enum FinancialGiftExemptionCategory
+{
+    NoExemption = 0,
+    WeddingOrCivilCeremonyChild,
+    WeddingOrCivilCeremonyGrandChildOrGreatGrandchild,
+    WeddingOrCivilCeremonyOtherNotChildGrandchildOrGreatGrandchild,
+    NormalGiftsOutOfYourIncome,
+    PaymentsToHelpWithAnotherPersonsLivingCosts,
+    GiftsToCharitiesAndPoliticalParties,
+    OtherGiftWhereAnnualExemptionAppliesCurrent,
+    OtherGiftWhereAnnualExemptionAppliesFromPreviousYear,
+    SmallGiftsUpTo250,
+}

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/FinancialGiftResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/FinancialGiftResourceRepresentation.cs
@@ -1,0 +1,15 @@
+﻿using Dahomey.Json.Attributes;
+
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+[JsonDiscriminator(nameof(EstateItemType.FinancialGift))]
+public class FinancialGiftResourceRepresentation : EstateItemResourceRepresentation
+{
+    public string? RecipientFirstName { get; init; }
+    public string? RecipientSurname { get; init; }
+    public string? Description { get; init; }
+    public decimal? GrossValue { get; init; }
+    public decimal ExemptionValue { get; init; }
+    public DateTime? DateOfGift { get; init; }
+    public FinancialGiftExemptionCategory? ExemptionCategory { get; init; }
+}


### PR DESCRIPTION
Add initial pass of the Financial Gift Estate Item model.  This is based on the current representation within the messages models and will require a further update when Gifts are fully integrated 