### PR TITLE
Adding in a hack to fix an issue with Dahomey.Json

### DIFF
--- a/src/Exizent.CaseManagement.Client/CaseManagementApiClient.cs
+++ b/src/Exizent.CaseManagement.Client/CaseManagementApiClient.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Exizent.CaseManagement.Client.Models;
 
 namespace Exizent.CaseManagement.Client;
@@ -31,7 +32,8 @@ public class CaseManagementApiClient : ICaseManagementApiClient
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadFromJsonAsync<CaseResourceRepresentation>(DefaultJsonSerializerOptions
-            .Instance);
+        var body = await response.Content.ReadAsStringAsync();
+
+        return JsonSerializer.Deserialize<CaseResourceRepresentation>(body, DefaultJsonSerializerOptions.Instance);
     }
 }


### PR DESCRIPTION
Adding in a hack to fix an issue whereby Dahomey.Json was throwing an InvalidOperationException: "Cannot skip tokens on partial JSON" exception when trying to use JsonSerializer.DeserializeAsync(stream).

Links: https://github.com/dahomey-technologies/Dahomey.Json/issues/110