### PR TITLE
UpdateCaseCollaborators contract change

### DIFF
--- a/src/Exizent.CaseManagement.Client/CaseManagementApiClient.cs
+++ b/src/Exizent.CaseManagement.Client/CaseManagementApiClient.cs
@@ -184,7 +184,7 @@ public class CaseManagementApiClient : ICaseManagementApiClient
         await _collaboratorsClient.UpdateCaseOwner(caseId, ownerId, cancellationToken);
     }
     
-    public async Task UpdateCaseCollaborators(Guid caseId, List<int> collaboratorIds, CancellationToken cancellationToken = default)
+    public async Task UpdateCaseCollaborators(Guid caseId, IEnumerable<int> collaboratorIds, CancellationToken cancellationToken = default)
     {
         await _collaboratorsClient.UpdateCaseCollaborators(caseId, collaboratorIds, cancellationToken);
     }

--- a/src/Exizent.CaseManagement.Client/CollaboratorsClient.cs
+++ b/src/Exizent.CaseManagement.Client/CollaboratorsClient.cs
@@ -19,7 +19,7 @@ internal class CollaboratorsClient
         response.EnsureSuccessStatusCode();
     }
     
-    public async Task UpdateCaseCollaborators(Guid caseId, List<int> collaboratorIds, CancellationToken cancellationToken = default)
+    public async Task UpdateCaseCollaborators(Guid caseId, IEnumerable<int> collaboratorIds, CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, $"/cases/{caseId}/collaborators");
         request.Content = JsonContent.Create(collaboratorIds);

--- a/src/Exizent.CaseManagement.Client/ICaseManagementApiClient.cs
+++ b/src/Exizent.CaseManagement.Client/ICaseManagementApiClient.cs
@@ -44,5 +44,5 @@ public interface ICaseManagementApiClient
         CancellationToken cancellationToken = default);
     Task DeleteDocument(Guid caseId, string documentKey, CancellationToken cancellationToken = default);
     Task UpdateCaseOwner(Guid caseId, int ownerId, CancellationToken cancellationToken = default);
-    Task UpdateCaseCollaborators(Guid caseId, List<int> collaboratorIds, CancellationToken cancellationToken = default);
+    Task UpdateCaseCollaborators(Guid caseId, IEnumerable<int> collaboratorIds, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Updating the contract for UpdateCaseCollaborators method
Swaping out use of List<int> for IEnumerable<int> as we dont care the type you pass so long as it is some kind of IEnumerable