### PR TITLE
Add ShareholdingIncome representation and JSON builder

### DIFF
--- a/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
+++ b/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
@@ -56,6 +56,7 @@ internal static class DefaultJsonSerializerOptions
         registry.RegisterType<IncomeResourceRepresentation>();
         registry.RegisterType<ReceiptIncomeResourceRepresentation>();
         registry.RegisterType<SumsReceivedIncomeResourceRepresentation>();
+        registry.RegisterType<ShareholdingIncomeResourceRepresentation>();
         
 
         return options;

--- a/src/Exizent.CaseManagement.Client/Models/Incomes/IncomeType.cs
+++ b/src/Exizent.CaseManagement.Client/Models/Incomes/IncomeType.cs
@@ -4,5 +4,6 @@ public enum IncomeType
 {
     Income,
     SumsReceived,
-    Receipt
+    Receipt,
+    ShareholdingIncome
 }

--- a/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
@@ -5,21 +5,21 @@ namespace Exizent.CaseManagement.Client.Models.Incomes;
 [JsonDiscriminator(nameof(IncomeType.ShareholdingIncome))]
 public class ShareholdingIncomeResourceRepresentation : IncomeBaseResourceRepresentation
 {
-    public Guid? EstateItemId { get; init; }
+    public Guid EstateItemId { get; init; }
 
-    public IncomeSource? Source { get; init; }
+    public IncomeSource Source { get; init; }
 
     public string? OtherSource { get; init; }
 
-    public DateTime? From { get; init; }
+    public DateTime From { get; init; }
 
-    public DateTime? To { get; init; }
+    public DateTime To { get; init; }
 
     public bool? IsTaxable { get; init; }
 
     public AmountType? AmountType { get; init; }
 
-    public IncomeDestination? Destination { get; init; }
+    public IncomeDestination Destination { get; init; }
 
     public string? OtherDestination { get; init; }
 
@@ -27,9 +27,9 @@ public class ShareholdingIncomeResourceRepresentation : IncomeBaseResourceRepres
 
     public decimal? ValueIncludingUpToDateOfDeath { get; init; }
 
-    public decimal? QuantityOfShares { get; init; }
+    public decimal QuantityOfShares { get; init; }
 
-    public decimal? SharePrice { get; init; }
+    public decimal SharePrice { get; init; }
 
     public decimal? Cash { get; init; }
 

--- a/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
@@ -1,0 +1,37 @@
+using Dahomey.Json.Attributes;
+
+namespace Exizent.CaseManagement.Client.Models.Incomes;
+
+[JsonDiscriminator(nameof(IncomeType.ShareholdingIncome))]
+public class ShareholdingIncomeResourceRepresentation : IncomeBaseResourceRepresentation
+{
+    public Guid? EstateItemId { get; init; }
+
+    public IncomeSource? Source { get; init; }
+
+    public string? OtherSource { get; init; }
+
+    public DateTime? From { get; init; }
+
+    public DateTime? To { get; init; }
+
+    public bool? IsTaxable { get; init; }
+
+    public AmountType? AmountType { get; init; }
+
+    public IncomeDestination? Destination { get; init; }
+
+    public string? OtherDestination { get; init; }
+
+    public bool IncludesValueUpToDateOfDeath { get; init; }
+
+    public decimal? ValueIncludingUpToDateOfDeath { get; init; }
+
+    public decimal? QuantityOfShares { get; init; }
+
+    public decimal? SharePrice { get; init; }
+
+    public decimal? Cash { get; init; }
+
+    public string? ShareholderReferenceNumber { get; init; }
+}

--- a/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/AllIncomeResourceRepresentationTypesData.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/AllIncomeResourceRepresentationTypesData.cs
@@ -11,5 +11,6 @@ public class AllIncomeResourceRepresentationTypesData : DataAttribute
         yield return new object[] { typeof(IncomeResourceRepresentation) };
         yield return new object[] { typeof(SumsReceivedIncomeResourceRepresentation) };
         yield return new object[] { typeof(ReceiptIncomeResourceRepresentation) };
+        yield return new object[] { typeof(ShareholdingIncomeResourceRepresentation) };
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/IncomeBaseJsonBuilderFactory.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/IncomeBaseJsonBuilderFactory.cs
@@ -10,6 +10,7 @@ public static class IncomeJsonBuilderFactory
             IncomeResourceRepresentation income => new IncomeJsonBuilder(income),
             SumsReceivedIncomeResourceRepresentation sumsReceived => new SumsReceivedIncomeJsonBuilder(sumsReceived),
             ReceiptIncomeResourceRepresentation receipt => new ReceiptIncomeJsonBuilder(receipt),
+            ShareholdingIncomeResourceRepresentation shareholding => new ShareholdingIncomeJsonBuilder(shareholding),
             _ => throw new ArgumentException("This income resource representation is not supported", resourceRepresentation.GetType().Name)
         };
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/ShareholdingIncomeJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/ShareholdingIncomeJsonBuilder.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.Json.Nodes;
+using Exizent.CaseManagement.Client.Models.Incomes;
+
+namespace Exizent.CaseManagement.Client.Tests.JsonBuilders.Incomes;
+
+public class ShareholdingIncomeJsonBuilder : IncomeBaseJsonBuilder<ShareholdingIncomeResourceRepresentation>
+{
+    public ShareholdingIncomeJsonBuilder(ShareholdingIncomeResourceRepresentation resourceRepresentation)
+        : base(resourceRepresentation)
+    {
+    }
+
+    protected override JsonObject InnerBuild(JsonObject jsonObject,
+        ShareholdingIncomeResourceRepresentation resourceRepresentation)
+    {
+        jsonObject.Add("type", nameof(IncomeType.ShareholdingIncome));
+        jsonObject.Add("estateItemId", resourceRepresentation.EstateItemId);
+        jsonObject.Add("source", resourceRepresentation.Source.ToString());
+        jsonObject.Add("otherSource", resourceRepresentation.OtherSource);
+        jsonObject.Add("from", resourceRepresentation.From);
+        jsonObject.Add("to", resourceRepresentation.To);
+        jsonObject.Add("isTaxable", resourceRepresentation.IsTaxable);
+        jsonObject.Add("amountType", resourceRepresentation.AmountType.ToString());
+        jsonObject.Add("destination", resourceRepresentation.Destination.ToString());
+        jsonObject.Add("otherDestination", resourceRepresentation.OtherDestination);
+        jsonObject.Add("includesValueUpToDateOfDeath", resourceRepresentation.IncludesValueUpToDateOfDeath);
+        jsonObject.Add("valueIncludingUpToDateOfDeath", resourceRepresentation.ValueIncludingUpToDateOfDeath);
+        jsonObject.Add("quantityOfShares", resourceRepresentation.QuantityOfShares);
+        jsonObject.Add("sharePrice", resourceRepresentation.SharePrice);
+        jsonObject.Add("cash", resourceRepresentation.Cash);
+        jsonObject.Add("shareholderReferenceNumber", resourceRepresentation.ShareholderReferenceNumber);
+
+        return jsonObject;
+    }
+}


### PR DESCRIPTION
This pull request introduces support for a new income type, "ShareholdingIncome", to the case management client. The main changes include adding the new model, updating the enum and registration logic, and extending test coverage and JSON builder support for this type.

**Core feature addition:**

* Added the `ShareholdingIncomeResourceRepresentation` model, representing shareholding income, with relevant properties and JSON discriminator attribute. (`src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs`)
* Extended the `IncomeType` enum to include `ShareholdingIncome`. (`src/Exizent.CaseManagement.Client/Models/Incomes/IncomeType.cs`)

**Serialization and registration updates:**

* Registered `ShareholdingIncomeResourceRepresentation` with the JSON serializer options registry to enable proper (de)serialization. (`src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs`)

**Test and builder support:**

* Added a new JSON builder, `ShareholdingIncomeJsonBuilder`, to support serialization in tests. (`tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/ShareholdingIncomeJsonBuilder.cs`)
* Updated test data and factory logic to include the new income type in test coverage and JSON builder creation. (`tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/AllIncomeResourceRepresentationTypesData.cs`, `tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/Incomes/IncomeBaseJsonBuilderFactory.cs`) [[1]](diffhunk://#diff-2b6286ff272095170a6d462c8cb6b710a7f9f90edb8a34af0192b293fd4cf513R14) [[2]](diffhunk://#diff-e3a76949ebba6e35c076005828715261c7dd1127e7824b5ccdc34e5c390978bfR13)