### PR TITLE
FD-1265: Compute Value for ShareholdingIncomeResourceRepresentation

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/Incomes/IncomeBaseResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/Incomes/IncomeBaseResourceRepresentation.cs
@@ -3,7 +3,7 @@
 public abstract class IncomeBaseResourceRepresentation: IIncomeResourceRepresentation
 {
     public Guid Id { get; init; }
-    public decimal? Value { get; init; }
+    public virtual decimal? Value { get; init; }
     public string? Notes { get; init; }
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }

--- a/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/Incomes/ShareholdingIncomeResourceRepresentation.cs
@@ -34,4 +34,7 @@ public class ShareholdingIncomeResourceRepresentation : IncomeBaseResourceRepres
     public decimal? Cash { get; init; }
 
     public string? ShareholderReferenceNumber { get; init; }
+
+    public override decimal? Value =>
+        QuantityOfShares * (SharePrice / 100) + (Cash ?? 0);
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithIncomes.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithIncomes.cs
@@ -1,4 +1,5 @@
-﻿using Exizent.CaseManagement.Client.Tests.JsonBuilders;
+﻿using Exizent.CaseManagement.Client.Models.Incomes;
+using Exizent.CaseManagement.Client.Tests.JsonBuilders;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -50,5 +51,36 @@ public sealed class GettingACaseWithIncomes : IClassFixture<Harness>
         caseDetails!.Id.Should().Be(caseResourceRepresentation.Id);
         caseDetails.Incomes.Single().Should()
             .BeEquivalentTo(income, o => o.RespectingRuntimeTypes());
+    }
+
+    [Fact]
+    public async Task ShouldComputeValueForShareholdingIncome()
+    {
+        var income = new ShareholdingIncomeResourceRepresentation
+        {
+            EstateItemId = Guid.NewGuid(),
+            QuantityOfShares = 100m,
+            SharePrice = 250m,   // pence — so £2.50 per share
+            Cash = 10m,
+            Source = IncomeSource.Dividend,
+            Destination = IncomeDestination.AssetValue,
+            From = new DateTime(2023, 1, 1),
+            To = new DateTime(2023, 12, 31)
+        };
+
+        var caseResourceRepresentation = new CaseResourceRepresentationBuilder()
+            .With(income)
+            .Build();
+
+        var body = CaseJsonBuilder.Build(caseResourceRepresentation);
+        _harness.ClientHandler.AddGetCaseResponse(caseResourceRepresentation.Id, body.ToJsonString());
+
+        var caseDetails = await _harness.Client.GetCase(caseResourceRepresentation.Id);
+
+        var shareholdingIncome = caseDetails!.Incomes.Single()
+            .Should().BeOfType<ShareholdingIncomeResourceRepresentation>().Subject;
+
+        // Value = QuantityOfShares * (SharePrice / 100) + Cash = 100 * 2.50 + 10 = 260
+        shareholdingIncome.Value.Should().Be(260m);
     }
 }


### PR DESCRIPTION
## What

Makes `IncomeBaseResourceRepresentation.Value` virtual and overrides it in `ShareholdingIncomeResourceRepresentation` to compute the value from the individual share fields:

```
Value = QuantityOfShares × (SharePrice / 100) + (Cash ?? 0)
```

## Why

The API sets `[JsonIgnore]` on `ShareholdingIncomeResourceRepresentation.Value` so it is never serialised over the wire. Without this change, all consumers reading `.Value` on the base type get `null` for shareholding income — silently excluding it from income sums (e.g. `SumOfLinkedIncomesAndReceipts` in `exizent-backend`).

Matches the formula used in the domain model (`ShareholdingIncome.Value` in `exizent.casemanagement`).

## Changes

- `IncomeBaseResourceRepresentation`: `Value` made `virtual`
- `ShareholdingIncomeResourceRepresentation`: `Value` overridden with computed expression
- `GettingACaseWithIncomes`: new test asserting computed value after deserialisation

Part of FD-1265.