### PR TITLE
FD-1314: Update physical shareholding resource representations to match API

### DIFF
--- a/src/Exizent.CaseManagement.Client/DateOnlyJsonConverter.cs
+++ b/src/Exizent.CaseManagement.Client/DateOnlyJsonConverter.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Exizent.CaseManagement.Client;
+
+internal sealed class DateOnlyJsonConverter : JsonConverter<DateOnly>
+{
+    private const string Format = "yyyy-MM-dd";
+
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => DateOnly.ParseExact(reader.GetString()!, Format, CultureInfo.InvariantCulture);
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToString(Format, CultureInfo.InvariantCulture));
+}

--- a/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
+++ b/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
@@ -14,6 +14,7 @@ internal static class DefaultJsonSerializerOptions
     private static JsonSerializerOptions CreateJsonSerializerOptions()
     {
         var options = new JsonSerializerOptions();
+        options.Converters.Add(new DateOnlyJsonConverter());
         options.Converters.Add(new JsonStringEnumConverter());
         options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;

--- a/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
+++ b/src/Exizent.CaseManagement.Client/DefaultJsonSerializerOptions.cs
@@ -44,6 +44,8 @@ internal static class DefaultJsonSerializerOptions
         registry.RegisterType<NomineeInvestmentAccountResourceRepresentation>();
         registry.RegisterType<PensionResourceRepresentation>();
         registry.RegisterType<PhysicalShareholdingResourceRepresentation>();
+        registry.RegisterType<SingleSharePriceValuationResourceRepresentation>();
+        registry.RegisterType<QuarterUpSharePriceValuationResourceRepresentation>();
         registry.RegisterType<PremiumBondResourceRepresentation>();
         registry.RegisterType<SecuredLoanResourceRepresentation>();
         registry.RegisterType<StateBenefitOverpaymentResourceRepresentation>();

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/CurrencyCode.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/CurrencyCode.cs
@@ -1,0 +1,317 @@
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public enum CurrencyCode
+{
+    /// <summary>United Arab Emirates Dirham</summary>
+    AED,
+    /// <summary>Afghanistan Afghani</summary>
+    AFN,
+    /// <summary>Albania Lek</summary>
+    ALL,
+    /// <summary>Armenia Dram</summary>
+    AMD,
+    /// <summary>Netherlands Antilles Guilder</summary>
+    ANG,
+    /// <summary>Angola Kwanza</summary>
+    AOA,
+    /// <summary>Argentina Peso</summary>
+    ARS,
+    /// <summary>Australia Dollar</summary>
+    AUD,
+    /// <summary>Aruba Florin</summary>
+    AWG,
+    /// <summary>Azerbaijan Manat</summary>
+    AZN,
+    /// <summary>Bosnia and Herzegovina Convertible Mark</summary>
+    BAM,
+    /// <summary>Barbados Dollar</summary>
+    BBD,
+    /// <summary>Bangladesh Taka</summary>
+    BDT,
+    /// <summary>Bulgaria Lev</summary>
+    BGN,
+    /// <summary>Bahrain Dinar</summary>
+    BHD,
+    /// <summary>Burundi Franc</summary>
+    BIF,
+    /// <summary>Bermuda Dollar</summary>
+    BMD,
+    /// <summary>Brunei Dollar</summary>
+    BND,
+    /// <summary>Bolivia Boliviano</summary>
+    BOB,
+    /// <summary>Brazil Real</summary>
+    BRL,
+    /// <summary>Bahamas Dollar</summary>
+    BSD,
+    /// <summary>Bhutan Ngultrum</summary>
+    BTN,
+    /// <summary>Botswana Pula</summary>
+    BWP,
+    /// <summary>Belarus Ruble</summary>
+    BYN,
+    /// <summary>Belize Dollar</summary>
+    BZD,
+    /// <summary>Canada Dollar</summary>
+    CAD,
+    /// <summary>Democratic Republic of the Congo Franc</summary>
+    CDF,
+    /// <summary>Switzerland Franc</summary>
+    CHF,
+    /// <summary>Chile Peso</summary>
+    CLP,
+    /// <summary>China Yuan</summary>
+    CNY,
+    /// <summary>Colombia Peso</summary>
+    COP,
+    /// <summary>Costa Rica Colon</summary>
+    CRC,
+    /// <summary>Cuba Peso</summary>
+    CUP,
+    /// <summary>Cape Verde Escudo</summary>
+    CVE,
+    /// <summary>Czechia Koruna</summary>
+    CZK,
+    /// <summary>Djibouti Franc</summary>
+    DJF,
+    /// <summary>Denmark Krone</summary>
+    DKK,
+    /// <summary>Dominican Republic Peso</summary>
+    DOP,
+    /// <summary>Algeria Dinar</summary>
+    DZD,
+    /// <summary>Egypt Pound</summary>
+    EGP,
+    /// <summary>Eritrea Nakfa</summary>
+    ERN,
+    /// <summary>Ethiopia Birr</summary>
+    ETB,
+    /// <summary>Euro</summary>
+    EUR,
+    /// <summary>Fiji Dollar</summary>
+    FJD,
+    /// <summary>Falkland Islands Pound</summary>
+    FKP,
+    /// <summary>United Kingdom Pound</summary>
+    GBP,
+    /// <summary>Georgia Lari</summary>
+    GEL,
+    /// <summary>Ghana Cedi</summary>
+    GHS,
+    /// <summary>Gibraltar Pound</summary>
+    GIP,
+    /// <summary>Gambia Dalasi</summary>
+    GMD,
+    /// <summary>Guinea Franc</summary>
+    GNF,
+    /// <summary>Guatemala Quetzal</summary>
+    GTQ,
+    /// <summary>Guyana Dollar</summary>
+    GYD,
+    /// <summary>Hong Kong Dollar</summary>
+    HKD,
+    /// <summary>Honduras Lempira</summary>
+    HNL,
+    /// <summary>Croatia Kuna</summary>
+    HRK,
+    /// <summary>Haiti Gourde</summary>
+    HTG,
+    /// <summary>Hungary Forint</summary>
+    HUF,
+    /// <summary>Indonesia Rupiah</summary>
+    IDR,
+    /// <summary>Ireland Pound</summary>
+    IEP,
+    /// <summary>Israel Shekel</summary>
+    ILS,
+    /// <summary>India Rupee</summary>
+    INR,
+    /// <summary>Iraq Dinar</summary>
+    IQD,
+    /// <summary>Iran Rial</summary>
+    IRR,
+    /// <summary>Iceland Króna</summary>
+    ISK,
+    /// <summary>Jamaica Dollar</summary>
+    JMD,
+    /// <summary>Jordan Dinar</summary>
+    JOD,
+    /// <summary>Japan Yen</summary>
+    JPY,
+    /// <summary>Kenya Shilling</summary>
+    KES,
+    /// <summary>Kyrgyzstan Som</summary>
+    KGS,
+    /// <summary>Cambodia Riel</summary>
+    KHR,
+    /// <summary>Kiribati Dollar</summary>
+    KID,
+    /// <summary>Comoros Franc</summary>
+    KMF,
+    /// <summary>North Korea Won</summary>
+    KPW,
+    /// <summary>South Korea Won</summary>
+    KRW,
+    /// <summary>Kuwait Dinar</summary>
+    KWD,
+    /// <summary>Cayman Islands Dollar</summary>
+    KYD,
+    /// <summary>Kazakhstan Tenge</summary>
+    KZT,
+    /// <summary>Laos Kip</summary>
+    LAK,
+    /// <summary>Lebanon Pound</summary>
+    LBP,
+    /// <summary>Sri Lanka Rupee</summary>
+    LKR,
+    /// <summary>Liberia Dollar</summary>
+    LRD,
+    /// <summary>Lesotho Loti</summary>
+    LSL,
+    /// <summary>Libya Dinar</summary>
+    LYD,
+    /// <summary>Morocco Dirham</summary>
+    MAD,
+    /// <summary>Moldova Leu</summary>
+    MDL,
+    /// <summary>Madagascar Ariary</summary>
+    MGA,
+    /// <summary>North Macedonia Denar</summary>
+    MKD,
+    /// <summary>Myanmar Kyat</summary>
+    MMK,
+    /// <summary>Mongolia Tugrik</summary>
+    MNT,
+    /// <summary>Macao Pataca</summary>
+    MOP,
+    /// <summary>Mauritania Ouguiya</summary>
+    MRU,
+    /// <summary>Mauritius Rupee</summary>
+    MUR,
+    /// <summary>Maldives Rufiyaa</summary>
+    MVR,
+    /// <summary>Malawi Kwacha</summary>
+    MWK,
+    /// <summary>Mexico Peso</summary>
+    MXN,
+    /// <summary>Malaysia Ringgit</summary>
+    MYR,
+    /// <summary>Mozambique Metical</summary>
+    MZN,
+    /// <summary>Namibia Dollar</summary>
+    NAD,
+    /// <summary>Nigeria Naira</summary>
+    NGN,
+    /// <summary>Nicaragua Córdoba</summary>
+    NIO,
+    /// <summary>Norway Krone</summary>
+    NOK,
+    /// <summary>Nepal Rupee</summary>
+    NPR,
+    /// <summary>New Zealand Dollar</summary>
+    NZD,
+    /// <summary>Oman Rial</summary>
+    OMR,
+    /// <summary>Panama Balboa</summary>
+    PAB,
+    /// <summary>Peru Sol</summary>
+    PEN,
+    /// <summary>Papua New Guinea Kina</summary>
+    PGK,
+    /// <summary>Philippines Peso</summary>
+    PHP,
+    /// <summary>Pakistan Rupee</summary>
+    PKR,
+    /// <summary>Poland Zloty</summary>
+    PLN,
+    /// <summary>Paraguay Guarani</summary>
+    PYG,
+    /// <summary>Qatar Riyal</summary>
+    QAR,
+    /// <summary>Romania Leu</summary>
+    RON,
+    /// <summary>Serbia Dinar</summary>
+    RSD,
+    /// <summary>Russia Ruble</summary>
+    RUB,
+    /// <summary>Rwanda Franc</summary>
+    RWF,
+    /// <summary>Saudi Arabia Riyal</summary>
+    SAR,
+    /// <summary>Solomon Islands Dollar</summary>
+    SBD,
+    /// <summary>Seychelles Rupee</summary>
+    SCR,
+    /// <summary>Sudan Pound</summary>
+    SDG,
+    /// <summary>Sweden Krona</summary>
+    SEK,
+    /// <summary>Singapore Dollar</summary>
+    SGD,
+    /// <summary>Saint Helena Pound</summary>
+    SHP,
+    /// <summary>Sierra Leone Leone</summary>
+    SLE,
+    /// <summary>Slovenia Tolar</summary>
+    SIT,
+    /// <summary>Slovakia Koruna</summary>
+    SKK,
+    /// <summary>Somalia Shilling</summary>
+    SOS,
+    /// <summary>Suriname Dollar</summary>
+    SRD,
+    /// <summary>South Sudan Pound</summary>
+    SSP,
+    /// <summary>Sao Tome and Principe Dobra</summary>
+    STN,
+    /// <summary>Syria Pound</summary>
+    SYP,
+    /// <summary>Eswatini Lilangeni</summary>
+    SZL,
+    /// <summary>Thailand Baht</summary>
+    THB,
+    /// <summary>Tajikistan Somoni</summary>
+    TJS,
+    /// <summary>Turkmenistan Manat</summary>
+    TMT,
+    /// <summary>Tunisia Dinar</summary>
+    TND,
+    /// <summary>Tonga Pa'anga</summary>
+    TOP,
+    /// <summary>Turkey Lira</summary>
+    TRY,
+    /// <summary>Trinidad and Tobago Dollar</summary>
+    TTD,
+    /// <summary>Tuvalu Dollar</summary>
+    TVD,
+    /// <summary>Taiwan Dollar</summary>
+    TWD,
+    /// <summary>Tanzania Shilling</summary>
+    TZS,
+    /// <summary>Ukraine Hryvnia</summary>
+    UAH,
+    /// <summary>Uganda Shilling</summary>
+    UGX,
+    /// <summary>United States Dollar</summary>
+    USD,
+    /// <summary>Uruguay Peso</summary>
+    UYU,
+    /// <summary>Uzbekistan Som</summary>
+    UZS,
+    /// <summary>Venezuela Bolivar</summary>
+    VES,
+    /// <summary>Vietnam Dong</summary>
+    VND,
+    /// <summary>Vanuatu Vatu</summary>
+    VUV,
+    /// <summary>Samoa Tala</summary>
+    WST,
+    /// <summary>Yemen Rial</summary>
+    YER,
+    /// <summary>South Africa Rand</summary>
+    ZAR,
+    /// <summary>Zambia Kwacha</summary>
+    ZMW,
+    /// <summary>Zimbabwe Dollar</summary>
+    ZWL
+}

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/GetShareRealisationResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/GetShareRealisationResourceRepresentation.cs
@@ -1,0 +1,17 @@
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public class GetShareRealisationResourceRepresentation
+{
+    public Guid Id { get; init; }
+    public DateOnly? ReceivedAt { get; init; }
+    public RealisationDestination? Destination { get; init; }
+    public string? OtherDestination { get; init; }
+    public decimal Quantity { get; init; }
+    public decimal Price { get; init; }
+    public decimal Value { get; init; }
+    public bool IncludeDateOfDeathShares { get; init; }
+    public IReadOnlyList<Guid> IncomeIds { get; init; } = Array.Empty<Guid>();
+    public Guid? CaseItemId { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
@@ -5,19 +5,33 @@ namespace Exizent.CaseManagement.Client.Models.EstateItems;
 [JsonDiscriminator(nameof(EstateItemType.PhysicalShareholding))]
 public class PhysicalShareholdingResourceRepresentation : EstateItemResourceRepresentation
 {
-    public AddressResourceRepresentation Address { get; init; } = null!;
+    public AddressResourceRepresentation? Address { get; init; }
     public string? ShareholdingName { get; init; }
+    public string? LookupId { get; init; }
     public string? ShareholderReferenceNumber { get; init; }
     public decimal? Quantity { get; init; }
     public string? Description { get; init; }
+    public string? ShareRegistrar { get; init; }
+    public PhysicalShareholdingValuationResourceRepresentation? Valuation { get; init; }
     public decimal? Price { get; init; }
     public decimal ProportionOwned { get; init; }
     public bool? IsPassedToSurvivingJointOwner { get; init; }
     public string? NotPassedDetails { get; init; }
     public decimal? DividendDue { get; init; }
     public string? ValuationBy { get; init; }
+    [Obsolete("Use IsListedOnRecognisedStockExchange instead.")]
     public bool IsQuotedOnLondonStockExchange { get; init; }
-    public EstateItemRealisationResourceRepresentation Realisation { get; init; } = null!;
+    public bool? IsListedOnRecognisedStockExchange { get; init; }
+    public bool? IsTradedElsewhere { get; init; }
+    public bool? IsListedOnUkExchanges { get; init; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
     public IReadOnlyList<Guid> JointOwnerIds { get; init; } = Array.Empty<Guid>();
+    public bool? OwnedForTwoYears { get; init; }
+    public decimal? BusinessRelief { get; init; }
+    public CurrencyCode TradingCurrencyCode { get; init; }
+    public decimal? ExchangeRate { get; init; }
+    public bool IsValidForInheritanceTax { get; init; }
+    public bool IsIncludedInEstateAccounts { get; init; }
     public bool HadControlOfTheCompany { get; init; }
+    public IReadOnlyList<GetShareRealisationResourceRepresentation> Realisations { get; init; } = Array.Empty<GetShareRealisationResourceRepresentation>();
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentationBase.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentationBase.cs
@@ -4,19 +4,42 @@ public abstract class PhysicalShareholdingResourceRepresentationBase : EstateIte
 {
     protected PhysicalShareholdingResourceRepresentationBase(): base(EstateItemType.PhysicalShareholding){}
 
-    public AddressResourceRepresentation Address { get; set; } = null!;
+    public AddressResourceRepresentation? Address { get; set; }
     public string? ShareholdingName { get; set; }
+    public string? LookupId { get; set; }
     public string? ShareholderReferenceNumber { get; set; }
     public decimal? Quantity { get; set; }
     public string? Description { get; set; }
-    public decimal? Price { get; set; }
+    public string? ShareRegistrar { get; set; }
+    public PhysicalShareholdingValuationResourceRepresentation? Valuation { get; set; }
     public decimal ProportionOwned { get; set; }
     public bool? IsPassedToSurvivingJointOwner { get; set; }
     public string? NotPassedDetails { get; set; }
     public decimal? DividendDue { get; set; }
     public string? ValuationBy { get; set; }
-    public bool IsQuotedOnLondonStockExchange { get; set; }
-    public EstateItemRealisationResourceRepresentation Realisation { get; set; } = null!;
-    public IReadOnlyList<Guid> JointOwnerIds { get; set; } = Array.Empty<Guid>();
+    public bool? IsListedOnRecognisedStockExchange { get; set; }
+    public bool? IsTradedElsewhere { get; set; }
+    public bool? IsListedOnUkExchanges { get; set; }
+    public EstateItemRealisationResourceRepresentation? Realisation { get; set; }
+    public bool? OwnedForTwoYears { get; set; }
+    public decimal? BusinessRelief { get; set; }
+    public CurrencyCode TradingCurrencyCode { get; set; }
+    public decimal? ExchangeRate { get; set; }
+    public bool IsValidForInheritanceTax { get; set; }
+    public bool IsIncludedInEstateAccounts { get; set; }
     public bool HadControlOfTheCompany { get; set; }
+    public IReadOnlyList<Guid> JointOwnerIds { get; set; } = Array.Empty<Guid>();
+    public IReadOnlyList<ShareRealisationResourceRepresentation>? Realisations { get; set; }
+
+    AddressResourceRepresentation IHasAddress.Address
+    {
+        get => Address!;
+        set => Address = value;
+    }
+
+    EstateItemRealisationResourceRepresentation IRealisable.Realisation
+    {
+        get => Realisation!;
+        set => Realisation = value;
+    }
 }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingValuationResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingValuationResourceRepresentation.cs
@@ -1,0 +1,24 @@
+using Dahomey.Json.Attributes;
+
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public enum ShareValuationType
+{
+    SinglePrice,
+    QuarterUp
+}
+
+public abstract class PhysicalShareholdingValuationResourceRepresentation { }
+
+[JsonDiscriminator(nameof(ShareValuationType.SinglePrice))]
+public class SingleSharePriceValuationResourceRepresentation : PhysicalShareholdingValuationResourceRepresentation
+{
+    public decimal? Price { get; init; }
+}
+
+[JsonDiscriminator(nameof(ShareValuationType.QuarterUp))]
+public class QuarterUpSharePriceValuationResourceRepresentation : PhysicalShareholdingValuationResourceRepresentation
+{
+    public decimal? LowPrice { get; init; }
+    public decimal? HighPrice { get; init; }
+}

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/ShareRealisationResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/ShareRealisationResourceRepresentation.cs
@@ -1,0 +1,13 @@
+namespace Exizent.CaseManagement.Client.Models.EstateItems;
+
+public class ShareRealisationResourceRepresentation
+{
+    public DateOnly? ReceivedAt { get; init; }
+    public RealisationDestination? Destination { get; init; }
+    public string? OtherDestination { get; init; }
+    public decimal Quantity { get; init; }
+    public decimal Price { get; init; }
+    public bool IncludeDateOfDeathShares { get; init; }
+    public IReadOnlyList<Guid>? IncomeIds { get; init; }
+    public Guid? CaseItemId { get; init; }
+}

--- a/tests/Exizent.CaseManagement.Client.Tests/Harness.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/Harness.cs
@@ -24,6 +24,8 @@ public sealed class Harness : IDisposable
             new TypeRelay(
                 typeof(PhysicalShareholdingValuationResourceRepresentation),
                 typeof(SingleSharePriceValuationResourceRepresentation)));
+
+        Fixture.Customize<DateOnly>(c => c.FromFactory<DateTime>(dt => DateOnly.FromDateTime(dt)));
     }
     
     public void Dispose()

--- a/tests/Exizent.CaseManagement.Client.Tests/Harness.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/Harness.cs
@@ -19,6 +19,11 @@ public sealed class Harness : IDisposable
         {
             BaseAddress = new Uri("https://testing.com")
         });
+
+        Fixture.Customizations.Add(
+            new TypeRelay(
+                typeof(PhysicalShareholdingValuationResourceRepresentation),
+                typeof(SingleSharePriceValuationResourceRepresentation)));
     }
     
     public void Dispose()

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
@@ -9,27 +9,60 @@ public class PhysicalShareholdingEstateItemJsonBuilder : EstateItemJsonBuilder<P
         : base(resourceRepresentation)
     {
     }
-      
+
     protected override JsonObject InnerBuild(JsonObject jsonObject,
         PhysicalShareholdingResourceRepresentation resourceRepresentation)
     {
         jsonObject.Add("type", nameof(EstateItemType.PhysicalShareholding));
-        jsonObject.Add("address", AddressJsonBuilder.Build(resourceRepresentation.Address));
+        jsonObject.Add("address", resourceRepresentation.Address is not null ? AddressJsonBuilder.Build(resourceRepresentation.Address) : null);
         jsonObject.Add("shareholdingName", resourceRepresentation.ShareholdingName);
+        jsonObject.Add("lookupId", resourceRepresentation.LookupId);
         jsonObject.Add("shareholderReferenceNumber", resourceRepresentation.ShareholderReferenceNumber);
         jsonObject.Add("quantity", resourceRepresentation.Quantity);
         jsonObject.Add("description", resourceRepresentation.Description);
+        jsonObject.Add("shareRegistrar", resourceRepresentation.ShareRegistrar);
+        jsonObject.Add("valuation", BuildValuation(resourceRepresentation.Valuation));
         jsonObject.Add("price", resourceRepresentation.Price);
         jsonObject.Add("proportionOwned", resourceRepresentation.ProportionOwned);
         jsonObject.Add("isPassedToSurvivingJointOwner", resourceRepresentation.IsPassedToSurvivingJointOwner);
         jsonObject.Add("notPassedDetails", resourceRepresentation.NotPassedDetails);
         jsonObject.Add("dividendDue", resourceRepresentation.DividendDue);
         jsonObject.Add("valuationBy", resourceRepresentation.ValuationBy);
+#pragma warning disable CS0618
         jsonObject.Add("isQuotedOnLondonStockExchange", resourceRepresentation.IsQuotedOnLondonStockExchange);
-        jsonObject.Add("realisation", EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation));
+#pragma warning restore CS0618
+        jsonObject.Add("isListedOnRecognisedStockExchange", resourceRepresentation.IsListedOnRecognisedStockExchange);
+        jsonObject.Add("isTradedElsewhere", resourceRepresentation.IsTradedElsewhere);
+        jsonObject.Add("isListedOnUkExchanges", resourceRepresentation.IsListedOnUkExchanges);
+        jsonObject.Add("realisation", resourceRepresentation.Realisation is not null ? EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation) : null);
         jsonObject.Add("jointOwnerIds", new JsonArray(resourceRepresentation.JointOwnerIds.Select(x => (JsonNode)JsonValue.Create(x)!).ToArray()));
+        jsonObject.Add("ownedForTwoYears", resourceRepresentation.OwnedForTwoYears);
+        jsonObject.Add("businessRelief", resourceRepresentation.BusinessRelief);
+        jsonObject.Add("tradingCurrencyCode", resourceRepresentation.TradingCurrencyCode.ToString());
+        jsonObject.Add("exchangeRate", resourceRepresentation.ExchangeRate);
+        jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);
+        jsonObject.Add("isIncludedInEstateAccounts", resourceRepresentation.IsIncludedInEstateAccounts);
         jsonObject.Add("hadControlOfTheCompany", resourceRepresentation.HadControlOfTheCompany);
+        jsonObject.Add("realisations", new JsonArray(resourceRepresentation.Realisations
+            .Select(r => (JsonNode)ShareRealisationJsonBuilder.Build(r)).ToArray()));
 
         return jsonObject;
     }
+
+    private static JsonNode? BuildValuation(PhysicalShareholdingValuationResourceRepresentation? valuation) =>
+        valuation switch
+        {
+            SingleSharePriceValuationResourceRepresentation single => new JsonObject
+            {
+                { "type", nameof(ShareValuationType.SinglePrice) },
+                { "price", single.Price }
+            },
+            QuarterUpSharePriceValuationResourceRepresentation quarterUp => new JsonObject
+            {
+                { "type", nameof(ShareValuationType.QuarterUp) },
+                { "lowPrice", quarterUp.LowPrice },
+                { "highPrice", quarterUp.HighPrice }
+            },
+            _ => null
+        };
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/ShareRealisationJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/ShareRealisationJsonBuilder.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Nodes;
+using Exizent.CaseManagement.Client.Models.EstateItems;
+
+namespace Exizent.CaseManagement.Client.Tests.JsonBuilders.EstateItems;
+
+public static class ShareRealisationJsonBuilder
+{
+    public static JsonObject Build(GetShareRealisationResourceRepresentation r) =>
+        new()
+        {
+            { "id", r.Id },
+            { "receivedAt", r.ReceivedAt?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) },
+            { "destination", r.Destination?.ToString() },
+            { "otherDestination", r.OtherDestination },
+            { "quantity", r.Quantity },
+            { "price", r.Price },
+            { "value", r.Value },
+            { "includeDateOfDeathShares", r.IncludeDateOfDeathShares },
+            { "incomeIds", new JsonArray(r.IncomeIds.Select(x => (JsonNode)JsonValue.Create(x)!).ToArray()) },
+            { "caseItemId", r.CaseItemId },
+            { "createdAt", r.CreatedAt },
+            { "updatedAt", r.UpdatedAt }
+        };
+}


### PR DESCRIPTION
## Summary

- Add `CurrencyCode` enum, polymorphic `PhysicalShareholdingValuationResourceRepresentation` (SinglePrice/QuarterUp), `ShareRealisationResourceRepresentation`, and `GetShareRealisationResourceRepresentation`
- Update `PhysicalShareholdingResourceRepresentationBase` and `PhysicalShareholdingResourceRepresentation` with all fields now present in the API: `LookupId`, `ShareRegistrar`, `Valuation`, `IsListedOnRecognisedStockExchange`, `IsTradedElsewhere`, `IsListedOnUkExchanges`, `OwnedForTwoYears`, `BusinessRelief`, `TradingCurrencyCode`, `ExchangeRate`, `IsValidForInheritanceTax`, `IsIncludedInEstateAccounts`, and a `Realisations` collection
- Mark `IsQuotedOnLondonStockExchange` as `[Obsolete]` on the GET representation (superseded by `IsListedOnRecognisedStockExchange`)
- Register valuation subtypes in `DefaultJsonSerializerOptions` for Dahomey polymorphic deserialisation
- Update `PhysicalShareholdingEstateItemJsonBuilder` to cover all new fields

## Test plan

- [ ] Build passes: `dotnet build`
- [ ] Existing tests pass
- [ ] Verify physical shareholding GET response deserialises `Valuation` (SinglePrice/QuarterUp) correctly
- [ ] Verify `Realisations` collection deserialises on GET response
- [ ] Verify PUT/POST round-trip includes new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)