### PR TITLE
[FD-1400]: Add C1 FormSettings RegistrarsToGroup to case client model

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/CaseResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/CaseResourceRepresentation.cs
@@ -4,6 +4,7 @@ using Exizent.CaseManagement.Client.Models.Deceased;
 using Exizent.CaseManagement.Client.Models.Distributions;
 using Exizent.CaseManagement.Client.Models.EstateItems;
 using Exizent.CaseManagement.Client.Models.Expenses;
+using Exizent.CaseManagement.Client.Models.FormSettings;
 using Exizent.CaseManagement.Client.Models.Incomes;
 using Exizent.CaseManagement.Client.Models.Organisations;
 using Exizent.CaseManagement.Client.Models.People;
@@ -31,4 +32,5 @@ public class CaseResourceRepresentation
     public CollaboratorResourceRepresentation Owner { get; init; } = null!;
     public IReadOnlyList<CollaboratorResourceRepresentation> Collaborators { get; init; } = null!;
     public CompanyAddressResourceRepresentation Address { get; init; } = null!;
+    public FormSettingsResourceRepresentation FormSettings { get; init; } = null!;
 }

--- a/src/Exizent.CaseManagement.Client/Models/FormSettings/C1FormSettingsResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/FormSettings/C1FormSettingsResourceRepresentation.cs
@@ -1,0 +1,6 @@
+namespace Exizent.CaseManagement.Client.Models.FormSettings;
+
+public class C1FormSettingsResourceRepresentation
+{
+    public IReadOnlyList<string> RegistrarsToGroup { get; init; } = null!;
+}

--- a/src/Exizent.CaseManagement.Client/Models/FormSettings/FormSettingsResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/FormSettings/FormSettingsResourceRepresentation.cs
@@ -1,0 +1,6 @@
+namespace Exizent.CaseManagement.Client.Models.FormSettings;
+
+public class FormSettingsResourceRepresentation
+{
+    public C1FormSettingsResourceRepresentation C1 { get; init; } = null!;
+}

--- a/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/CaseResourceRepresentationBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/CaseResourceRepresentationBuilder.cs
@@ -6,6 +6,7 @@ using Exizent.CaseManagement.Client.Models.Deceased;
 using Exizent.CaseManagement.Client.Models.Distributions;
 using Exizent.CaseManagement.Client.Models.EstateItems;
 using Exizent.CaseManagement.Client.Models.Expenses;
+using Exizent.CaseManagement.Client.Models.FormSettings;
 using Exizent.CaseManagement.Client.Models.Incomes;
 using Exizent.CaseManagement.Client.Models.Organisations;
 using Exizent.CaseManagement.Client.Models.People;
@@ -30,6 +31,7 @@ public class CaseResourceRepresentationBuilder
     private readonly List<CollaboratorResourceRepresentation> _collaborators = new();
     private CollaboratorResourceRepresentation? _owner = new();
     private CompanyAddressResourceRepresentation _address = new();
+    private FormSettingsResourceRepresentation? _formSettings;
 
     public CaseResourceRepresentationBuilder With(CompanyResourceRepresentation? company)
     {
@@ -119,6 +121,12 @@ public class CaseResourceRepresentationBuilder
         return this;
     }
 
+    public CaseResourceRepresentationBuilder With(FormSettingsResourceRepresentation formSettings)
+    {
+        _formSettings = formSettings;
+        return this;
+    }
+
     public CaseResourceRepresentation Build()
     {
         return new CaseResourceRepresentation
@@ -140,6 +148,13 @@ public class CaseResourceRepresentationBuilder
             Owner = _owner ?? _fixture.Create<CollaboratorResourceRepresentation>(),
             Collaborators = _collaborators,
             Address = _address,
+            FormSettings = _formSettings ?? new FormSettingsResourceRepresentation
+            {
+                C1 = new C1FormSettingsResourceRepresentation
+                {
+                    RegistrarsToGroup = Array.Empty<string>()
+                }
+            },
         };
     }
 }

--- a/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithFormSettings.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithFormSettings.cs
@@ -1,0 +1,57 @@
+using Exizent.CaseManagement.Client.Models.FormSettings;
+using Exizent.CaseManagement.Client.Tests.JsonBuilders;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Exizent.CaseManagement.Client.Tests.GettingACaseTests;
+
+public sealed class GettingACaseWithFormSettings : IClassFixture<Harness>
+{
+    private readonly Harness _harness;
+
+    public GettingACaseWithFormSettings(Harness harness) => _harness = harness;
+
+    [Fact]
+    public async Task ShouldReturnEmptyRegistrarsToGroup()
+    {
+        var caseResourceRepresentation = new CaseResourceRepresentationBuilder()
+            .Build();
+
+        _harness.ClientHandler.AddGetCaseResponse(caseResourceRepresentation.Id,
+            CaseJsonBuilder.Build(caseResourceRepresentation).ToJsonString());
+
+        var caseDetails = await _harness.Client.GetCase(caseResourceRepresentation.Id);
+
+        using var _ = new AssertionScope();
+        caseDetails.Should().NotBeNull();
+        caseDetails!.FormSettings.Should().NotBeNull();
+        caseDetails.FormSettings.C1.RegistrarsToGroup.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldDeserialiseRegistrarsToGroupOnC1FormSettings()
+    {
+        var expectedRegistrars = new[] { "Equiniti", "Computershare" };
+        var formSettings = new FormSettingsResourceRepresentation
+        {
+            C1 = new C1FormSettingsResourceRepresentation
+            {
+                RegistrarsToGroup = expectedRegistrars
+            }
+        };
+        var caseResourceRepresentation = new CaseResourceRepresentationBuilder()
+            .With(formSettings)
+            .Build();
+
+        _harness.ClientHandler.AddGetCaseResponse(caseResourceRepresentation.Id,
+            CaseJsonBuilder.Build(caseResourceRepresentation).ToJsonString());
+
+        var caseDetails = await _harness.Client.GetCase(caseResourceRepresentation.Id);
+
+        using var _ = new AssertionScope();
+        caseDetails.Should().NotBeNull();
+        caseDetails!.FormSettings.C1.RegistrarsToGroup.Should()
+            .BeEquivalentTo(expectedRegistrars);
+    }
+}

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/CaseJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/CaseJsonBuilder.cs
@@ -2,6 +2,7 @@
 using Exizent.CaseManagement.Client.Models;
 using Exizent.CaseManagement.Client.Tests.JsonBuilders.EstateItems;
 using Exizent.CaseManagement.Client.Tests.JsonBuilders.Expenses;
+using Exizent.CaseManagement.Client.Tests.JsonBuilders.FormSettings;
 using Exizent.CaseManagement.Client.Tests.JsonBuilders.Incomes;
 
 namespace Exizent.CaseManagement.Client.Tests.JsonBuilders;
@@ -75,6 +76,11 @@ public static class CaseJsonBuilder
         if (address is not null)
         {
             jsonObject.Add("address", address);
+        }
+
+        if (resourceRepresentation.FormSettings is not null)
+        {
+            jsonObject.Add("formSettings", FormSettingsJsonBuilder.Build(resourceRepresentation.FormSettings));
         }
 
         return jsonObject;

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/FormSettings/FormSettingsJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/FormSettings/FormSettingsJsonBuilder.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using Exizent.CaseManagement.Client.Models.FormSettings;
+
+namespace Exizent.CaseManagement.Client.Tests.JsonBuilders.FormSettings;
+
+public static class FormSettingsJsonBuilder
+{
+    public static JsonObject Build(FormSettingsResourceRepresentation resourceRepresentation)
+    {
+        return new JsonObject
+        {
+            { "c1", BuildC1(resourceRepresentation.C1) },
+        };
+    }
+
+    private static JsonObject BuildC1(C1FormSettingsResourceRepresentation c1)
+    {
+        return new JsonObject
+        {
+            {
+                "registrarsToGroup",
+                new JsonArray(c1.RegistrarsToGroup.Select(x => JsonValue.Create(x)).ToArray<JsonNode?>())
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Context

The casemanagement API (FD-1400) added a new case-level property holding the list of registrars to group by on the **C1** (Scottish Confirmation form): `Case.FormSettings.C1.RegistrarsToGroup` (`IReadOnlyList<string>`). The API GET case endpoint already returns it under `formSettings.c1.registrarsToGroup`.

This client library did not yet model `FormSettings`, so consumers silently dropped the new field. This PR adds the matching client models so it round-trips through `Client.GetCase(...)`, mirroring the recent FD-1349 ShareSettlement/PaySurplus client-model work.

## Changes

- **New models** under `Models/FormSettings/`: `FormSettingsResourceRepresentation` + `C1FormSettingsResourceRepresentation` (plain classes, `init` properties, camelCase via the global naming policy — no `[JsonPropertyName]` attributes).
- `CaseResourceRepresentation` gains a `FormSettings` property.
- **Tests**: new `FormSettingsJsonBuilder` wired into `CaseJsonBuilder`; `With(FormSettings...)` added to `CaseResourceRepresentationBuilder` (defaults to an empty `RegistrarsToGroup` block); new `GettingACaseWithFormSettings` test class covering empty and populated lists.

## Verification

- Client project compiles.
- New `GettingACaseWithFormSettings` tests pass; full `GettingACase` suite (101 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)