### PR TITLE
FD-1556: Split physical shareholding business relief into 50%/100%

### DIFF
--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentation.cs
@@ -27,7 +27,8 @@ public class PhysicalShareholdingResourceRepresentation : EstateItemResourceRepr
     public EstateItemRealisationResourceRepresentation? Realisation { get; init; }
     public IReadOnlyList<Guid> JointOwnerIds { get; init; } = Array.Empty<Guid>();
     public bool? OwnedForTwoYears { get; init; }
-    public decimal? BusinessRelief { get; init; }
+    public decimal? BusinessReliefAt50Percent { get; init; }
+    public decimal? BusinessReliefAt100Percent { get; init; }
     public CurrencyCode TradingCurrencyCode { get; init; }
     public decimal? ExchangeRate { get; init; }
     public bool IsValidForInheritanceTax { get; init; }

--- a/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentationBase.cs
+++ b/src/Exizent.CaseManagement.Client/Models/EstateItems/PhysicalShareholdingResourceRepresentationBase.cs
@@ -22,7 +22,8 @@ public abstract class PhysicalShareholdingResourceRepresentationBase : EstateIte
     public bool? IsListedOnUkExchanges { get; set; }
     public EstateItemRealisationResourceRepresentation? Realisation { get; set; }
     public bool? OwnedForTwoYears { get; set; }
-    public decimal? BusinessRelief { get; set; }
+    public decimal? BusinessReliefAt50Percent { get; set; }
+    public decimal? BusinessReliefAt100Percent { get; set; }
     public CurrencyCode TradingCurrencyCode { get; set; }
     public decimal? ExchangeRate { get; set; }
     public bool IsValidForInheritanceTax { get; set; }

--- a/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithPhysicalShareholdingBusinessRelief.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/GettingACaseTests/GettingACaseWithPhysicalShareholdingBusinessRelief.cs
@@ -1,0 +1,73 @@
+using Exizent.CaseManagement.Client.Models;
+using Exizent.CaseManagement.Client.Models.EstateItems;
+using Exizent.CaseManagement.Client.Tests.JsonBuilders;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Exizent.CaseManagement.Client.Tests.GettingACaseTests;
+
+public sealed class GettingACaseWithPhysicalShareholdingBusinessRelief : IClassFixture<Harness>
+{
+    private readonly Harness _harness;
+
+    public GettingACaseWithPhysicalShareholdingBusinessRelief(Harness harness) => _harness = harness;
+
+    [Fact]
+    public async Task ShouldDeserialiseBusinessReliefSplitAcross50And100Percent()
+    {
+        var shareholding = new PhysicalShareholdingResourceRepresentation
+        {
+            Id = Guid.NewGuid(),
+            OwnedForTwoYears = true,
+            BusinessReliefAt50Percent = 250.50m,
+            BusinessReliefAt100Percent = 749.50m
+        };
+
+        var caseDetails = await GetCaseWith(shareholding);
+
+        using var _ = new AssertionScope();
+        var actual = caseDetails.EstateItems.Single().Should()
+            .BeOfType<PhysicalShareholdingResourceRepresentation>().Subject;
+        actual.OwnedForTwoYears.Should().BeTrue();
+        actual.BusinessReliefAt50Percent.Should().Be(250.50m);
+        actual.BusinessReliefAt100Percent.Should().Be(749.50m);
+    }
+
+    [Fact]
+    public async Task ShouldDeserialiseNullBusinessReliefWhenNotClaimed()
+    {
+        var shareholding = new PhysicalShareholdingResourceRepresentation
+        {
+            Id = Guid.NewGuid(),
+            OwnedForTwoYears = false,
+            BusinessReliefAt50Percent = null,
+            BusinessReliefAt100Percent = null
+        };
+
+        var caseDetails = await GetCaseWith(shareholding);
+
+        using var _ = new AssertionScope();
+        var actual = caseDetails.EstateItems.Single().Should()
+            .BeOfType<PhysicalShareholdingResourceRepresentation>().Subject;
+        actual.OwnedForTwoYears.Should().BeFalse();
+        actual.BusinessReliefAt50Percent.Should().BeNull();
+        actual.BusinessReliefAt100Percent.Should().BeNull();
+    }
+
+    private async Task<CaseResourceRepresentation> GetCaseWith(
+        PhysicalShareholdingResourceRepresentation shareholding)
+    {
+        var caseResourceRepresentation = new CaseResourceRepresentationBuilder()
+            .With(shareholding)
+            .Build();
+
+        _harness.ClientHandler.AddGetCaseResponse(caseResourceRepresentation.Id,
+            CaseJsonBuilder.Build(caseResourceRepresentation).ToJsonString());
+
+        var caseDetails = await _harness.Client.GetCase(caseResourceRepresentation.Id);
+
+        caseDetails.Should().NotBeNull();
+        return caseDetails!;
+    }
+}

--- a/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
+++ b/tests/Exizent.CaseManagement.Client.Tests/JsonBuilders/EstateItems/PhysicalShareholdingEstateItemJsonBuilder.cs
@@ -37,7 +37,8 @@ public class PhysicalShareholdingEstateItemJsonBuilder : EstateItemJsonBuilder<P
         jsonObject.Add("realisation", resourceRepresentation.Realisation is not null ? EstateItemRealisationJsonBuilder.Build(resourceRepresentation.Realisation) : null);
         jsonObject.Add("jointOwnerIds", new JsonArray(resourceRepresentation.JointOwnerIds.Select(x => (JsonNode)JsonValue.Create(x)!).ToArray()));
         jsonObject.Add("ownedForTwoYears", resourceRepresentation.OwnedForTwoYears);
-        jsonObject.Add("businessRelief", resourceRepresentation.BusinessRelief);
+        jsonObject.Add("businessReliefAt50Percent", resourceRepresentation.BusinessReliefAt50Percent);
+        jsonObject.Add("businessReliefAt100Percent", resourceRepresentation.BusinessReliefAt100Percent);
         jsonObject.Add("tradingCurrencyCode", resourceRepresentation.TradingCurrencyCode.ToString());
         jsonObject.Add("exchangeRate", resourceRepresentation.ExchangeRate);
         jsonObject.Add("isValidForInheritanceTax", resourceRepresentation.IsValidForInheritanceTax);


### PR DESCRIPTION
## Why

[FD-1556](https://exizent.atlassian.net/browse/FD-1556) needs jointly owned physical shareholdings that claim Business Property Relief to map to **IHT404 Q1** (instead of Q6), with the relief values mapped to **IHT404 Q4** split across 100% and 50% relief.

Those values aren't reachable today. The Cases API returns `businessReliefAt50Percent` / `businessReliefAt100Percent` (see `GetPhysicalShareholdingResourceRepresentation` in `exizent.casemanagement`), but this client still exposes the superseded single `businessRelief` property, which the API no longer emits — so it deserialises as `null` every time.

## What

- Replace `decimal? BusinessRelief` with `BusinessReliefAt50Percent` and `BusinessReliefAt100Percent` on `PhysicalShareholdingResourceRepresentation` (get) and `PhysicalShareholdingResourceRepresentationBase` (post/put).
- Emit the new wire names from `PhysicalShareholdingEstateItemJsonBuilder`, which keeps the existing `ShouldReturnEstateItem` round-trip theory honest about the real API field names.
- Add `GettingACaseWithPhysicalShareholdingBusinessRelief` covering both the claimed case (values populated) and the unclaimed case (nulls).

## Breaking change

`BusinessRelief` is removed rather than deprecated. It's dead on the wire, so it could only ever have deserialised to `null`. I grepped `exizent.caseforms`, `exizent.forms`, `exizent.correspondence.api` and `exizent.integrations.api` for both reads and writes of it and found no consumers.

## Testing

`docker build --target test -f ./Dockerfile .` — 134 unit + 50 integration tests pass.

## Follow-up

Once this merges and publishes, `exizent.caseforms` bumps its `Exizent.CaseManagement.Client` reference (currently `0.0.577-preview`) and implements the IHT404 Box 1 / Box 4 mapping for FD-1556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)